### PR TITLE
add decimals field as opt feature

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -8,7 +8,7 @@ members = [
 resolver = "2"
 
 [workspace.package]
-version = "0.1.0"
+version = "0.1.1"
 edition = "2021"
 
 [workspace.dependencies]

--- a/replay-engine/Cargo.toml
+++ b/replay-engine/Cargo.toml
@@ -3,6 +3,10 @@ name = "replay-engine"
 version = { workspace = true }
 edition = { workspace = true }
 
+[features]
+default = []
+decimals = []
+
 [dependencies]
 bincode = { workspace = true }
 serde = { workspace = true }

--- a/replay-engine/src/decoded_instructions.rs
+++ b/replay-engine/src/decoded_instructions.rs
@@ -322,6 +322,10 @@ pub struct DecodedInitializePool {
   pub key_token_program: String,
   pub key_system_program: String,
   pub key_rent: String,
+  #[cfg(feature = "decimals")]
+  pub decimals_token_mint_a: u8,
+  #[cfg(feature = "decimals")]
+  pub decimals_token_mint_b: u8,
 }
 
 #[derive(Serialize, Deserialize, Debug, PartialEq, Eq, Clone)]
@@ -367,6 +371,8 @@ pub struct DecodedInitializeReward {
   pub key_token_program: String,
   pub key_system_program: String,
   pub key_rent: String,
+  #[cfg(feature = "decimals")]
+  pub decimals_reward_mint: u8,
 }
 
 #[derive(Serialize, Deserialize, Debug, PartialEq, Eq, Clone)]
@@ -830,6 +836,10 @@ pub struct DecodedInitializePoolV2 {
   pub key_token_program_b: String,
   pub key_system_program: String,
   pub key_rent: String,
+  #[cfg(feature = "decimals")]
+  pub decimals_token_mint_a: u8,
+  #[cfg(feature = "decimals")]
+  pub decimals_token_mint_b: u8,
 }
 
 #[derive(Serialize, Deserialize, Debug, PartialEq, Eq, Clone)]
@@ -845,6 +855,8 @@ pub struct DecodedInitializeRewardV2 {
   pub key_reward_token_program: String,
   pub key_system_program: String,
   pub key_rent: String,
+  #[cfg(feature = "decimals")]
+  pub decimals_reward_mint: u8,
 }
 
 #[derive(Serialize, Deserialize, Debug, PartialEq, Eq, Clone)]


### PR DESCRIPTION
whirlpool-transaction file will provide decimals for
- initializePool
- initializePoolV2
- initializeReward
- initializeRewardV2

But replay doesn't need it, so it is optional feature (for now) to avoid breaking change.