### PR TITLE
Tweak cu limit on replay env

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3306,7 +3306,7 @@ checksum = "adad44e29e4c806119491a7f06f03de4d1af22c3a680dd47f1e6e179439d1f56"
 
 [[package]]
 name = "replay-engine"
-version = "0.1.14"
+version = "0.1.15"
 dependencies = [
  "anchor-client",
  "anchor-lang",
@@ -5950,7 +5950,7 @@ dependencies = [
 
 [[package]]
 name = "whirlpool-regression-test"
-version = "0.1.14"
+version = "0.1.15"
 dependencies = [
  "anchor-lang",
  "chrono",
@@ -5963,7 +5963,7 @@ dependencies = [
 
 [[package]]
 name = "whirlpool-replay"
-version = "0.1.14"
+version = "0.1.15"
 dependencies = [
  "anchor-lang",
  "clap 4.5.6",
@@ -5974,7 +5974,7 @@ dependencies = [
 
 [[package]]
 name = "whirlpool-replayer"
-version = "0.1.14"
+version = "0.1.15"
 dependencies = [
  "base64 0.21.7",
  "bincode",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -9,7 +9,7 @@ members = [
 resolver = "2"
 
 [workspace.package]
-version = "0.1.14"
+version = "0.1.15"
 edition = "2021"
 
 [workspace.dependencies]

--- a/replay-engine/src/replay_environment.rs
+++ b/replay-engine/src/replay_environment.rs
@@ -393,6 +393,8 @@ pub struct ReplayEnvironmentBuilder {
 }
 
 impl ReplayEnvironmentBuilder {
+    const COMPUTE_UNIT_MAX: u64 = 2_000_000; // 1.4M + 0.6M because replayed instructions contain Memo instruction.
+
     fn new() -> Self {
         let faucet = Keypair::new();
         let mut config = GenesisConfig::new(
@@ -623,7 +625,7 @@ impl ReplayEnvironmentBuilder {
 
         // set compute budget to max
         let mut runtime_config = RuntimeConfig::default();
-        runtime_config.compute_budget = Some(solana_program_runtime::compute_budget::ComputeBudget::new(1_400_000u64));
+        runtime_config.compute_budget = Some(solana_program_runtime::compute_budget::ComputeBudget::new(Self::COMPUTE_UNIT_MAX));
 
         let bank_slot0 = Bank::new_with_paths(
             &self.config,


### PR DESCRIPTION
We use 1.4M as CU limit because this limit is used in the mainnet.
But in replay env, we added memo instruction in the replay transaction to avoid hash conflict.
So a transaction which consumed about 1.4M CU may fail due to CU limit exceeded error.
Therefore, we need to increase the CU limit.

Example failed tx:
https://solscan.io/tx/3kKaaQUGVik6tZ2uEUwgrtLBaUe7VBJ8FfKDcuvwzBPyCQdCWEoKsmaYg7NWTNHXyyHbTgpCVRLugSH7fhEdpwWd

This transaction consumed `1,399,405` CU. So if we add a Memo instruction, the CU usage exceeds 1.4M limit.