### PR TITLE
fix reposition_liquidity_v2

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3306,7 +3306,7 @@ checksum = "adad44e29e4c806119491a7f06f03de4d1af22c3a680dd47f1e6e179439d1f56"
 
 [[package]]
 name = "replay-engine"
-version = "0.1.15"
+version = "0.1.16"
 dependencies = [
  "anchor-client",
  "anchor-lang",
@@ -5950,7 +5950,7 @@ dependencies = [
 
 [[package]]
 name = "whirlpool-regression-test"
-version = "0.1.15"
+version = "0.1.16"
 dependencies = [
  "anchor-lang",
  "chrono",
@@ -5963,7 +5963,7 @@ dependencies = [
 
 [[package]]
 name = "whirlpool-replay"
-version = "0.1.15"
+version = "0.1.16"
 dependencies = [
  "anchor-lang",
  "clap 4.5.6",
@@ -5974,7 +5974,7 @@ dependencies = [
 
 [[package]]
 name = "whirlpool-replayer"
-version = "0.1.15"
+version = "0.1.16"
 dependencies = [
  "base64 0.21.7",
  "bincode",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -9,7 +9,7 @@ members = [
 resolver = "2"
 
 [workspace.package]
-version = "0.1.15"
+version = "0.1.16"
 edition = "2021"
 
 [workspace.dependencies]

--- a/replay-engine/src/replay_instructions/reposition_liquidity_v2.rs
+++ b/replay-engine/src/replay_instructions/reposition_liquidity_v2.rs
@@ -173,13 +173,13 @@ pub fn replay(req: ReplayInstructionParams<decoded_instructions::DecodedRepositi
     vault_amount_b
   );
   // existing_tick_array_lower
-  replayer.set_whirlpool_account(&ix.key_existing_tick_array_lower, accounts);
+  replayer.set_whirlpool_account_with_additional_lamports(&ix.key_existing_tick_array_lower, accounts); // add lamports to collect rent of 2 ticks
   // existing_tick_array_upper
-  replayer.set_whirlpool_account(&ix.key_existing_tick_array_upper, accounts);
+  replayer.set_whirlpool_account_with_additional_lamports(&ix.key_existing_tick_array_upper, accounts); // add lamports to collect rent of 2 ticks
   // new_tick_array_lower
-  replayer.set_whirlpool_account(&ix.key_new_tick_array_lower, accounts);
+  replayer.set_whirlpool_account_with_additional_lamports(&ix.key_new_tick_array_lower, accounts); // add lamports to collect rent of 2 ticks
   // new_tick_array_upper
-  replayer.set_whirlpool_account(&ix.key_new_tick_array_upper, accounts);
+  replayer.set_whirlpool_account_with_additional_lamports(&ix.key_new_tick_array_upper, accounts); // add lamports to collect rent of 2 ticks
   // system_program
 
   let method = match ix.data_method {


### PR DESCRIPTION
In reposition_liquidity_v2 context, TickArrays must be set with additional rent to collect rent for ticks.